### PR TITLE
output proof state for each node to JSON

### DIFF
--- a/dataloader/dataloader-core/pyproject.toml
+++ b/dataloader/dataloader-core/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "dataloader"
+dynamic = ["version"]
 requires-python = ">=3.7"
 classifiers = [
     "Programming Language :: Rust",

--- a/src/search_strategies.py
+++ b/src/search_strategies.py
@@ -192,6 +192,9 @@ class SearchGraph:
         output_dict = {"name": node.prediction}
         if node_handle.attr["fillcolor"]:
             output_dict["color"] = node_handle.attr["fillcolor"]
+        if node.context_before:
+            output_dict["proofcontext"] = node.context_before.obligations.focused_hyps
+            output_dict["proofgoal"] = node.context_before.obligations.focused_goal
         if node.children:
             output_dict["children"] = [self.print_label_recursive(i) for i in node.children]
 


### PR DESCRIPTION
Output the proof state information (proof context and proof goal) into the JSON file that represents the proof search tree. This information is used to visualize proof state for each tree node in the coq-synthesis-vscode extension. 